### PR TITLE
Fix typo

### DIFF
--- a/templates/workload.template.yaml
+++ b/templates/workload.template.yaml
@@ -309,7 +309,7 @@ Resources:
                   - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
                   - !Sub ['arn:${AWS::Partition}:s3:::${S3Bucket}', S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]]
                   - !Sub "arn:${AWS::Partition}:s3:::${MediaS3Bucket}/*"
-                  - !Sub "arn:${AWS::Partition}:s3:::${MediaS3Bucket}'"
+                  - !Sub "arn:${AWS::Partition}:s3:::${MediaS3Bucket}"
         - PolicyName: NiceDCVLicenseS3BucketAccess
           PolicyDocument:
             Version: '2012-10-17'


### PR DESCRIPTION
As this single quote is between two double quotes, its being added to policy and cause access denied error for file copy in install script. Removing the single quote